### PR TITLE
Fix user scopes

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,7 +10,6 @@ AllCops:
     - "bin/**/*"
     - "vendor/**/*"
     - "node_modules/**/*"
-    - "spec/**/*"
   TargetRubyVersion: 2.4
 
 Metrics/LineLength:

--- a/app/controllers/things/discovery_controller.rb
+++ b/app/controllers/things/discovery_controller.rb
@@ -1,7 +1,9 @@
 class Things::DiscoveryController < ApplicationController
+  before_action :authenticate_user
+
   def index
     validate_params
-    home = Home.find(params[:home_id])
+    home = current_user.homes.find(params[:home_id])
     type = params[:type]
 
     response = DiscoverDevices.new(home: home, type: type).perform

--- a/app/controllers/things/lights_controller.rb
+++ b/app/controllers/things/lights_controller.rb
@@ -2,7 +2,7 @@ class Things::LightsController < ThingsController
   before_action :authenticate_user
 
   def create
-    home = Home.find(params[:home_id])
+    home = current_user.homes.find(params[:home_id])
     thing = home.lights.build(thing_params)
 
     if thing.save

--- a/app/controllers/things/locks_controller.rb
+++ b/app/controllers/things/locks_controller.rb
@@ -2,7 +2,7 @@ class Things::LocksController < ThingsController
   before_action :authenticate_user
 
   def create
-    home = Home.find(params[:home_id])
+    home = current_user.homes.find(params[:home_id])
     thing = home.locks.build(thing_params)
 
     if thing.save

--- a/app/controllers/things/status/light_controller.rb
+++ b/app/controllers/things/status/light_controller.rb
@@ -2,7 +2,7 @@ class Things::Status::LightController < Things::StatusController
   private
 
   def fetch_thing
-    home = Home.find(params[:home_id])
+    home = current_user.homes.find(params[:home_id])
     home.things.find(params[:light_id])
   end
 

--- a/app/controllers/things/status/lock_controller.rb
+++ b/app/controllers/things/status/lock_controller.rb
@@ -2,7 +2,7 @@ class Things::Status::LockController < Things::StatusController
   private
 
   def fetch_thing
-    home = Home.find(params[:home_id])
+    home = current_user.homes.find(params[:home_id])
     home.things.find(params[:lock_id])
   end
 

--- a/app/controllers/things/status/thermostat_controller.rb
+++ b/app/controllers/things/status/thermostat_controller.rb
@@ -2,7 +2,7 @@ class Things::Status::ThermostatController < Things::StatusController
   private
 
   def fetch_thing
-    home = Home.find(params[:home_id])
+    home = current_user.homes.find(params[:home_id])
     home.things.find(params[:thermostat_id])
   end
 

--- a/app/controllers/things/status/weather_controller.rb
+++ b/app/controllers/things/status/weather_controller.rb
@@ -2,7 +2,7 @@ class Things::Status::WeatherController < Things::StatusController
   private
 
   def fetch_thing
-    home = Home.find(params[:home_id])
+    home = current_user.homes.find(params[:home_id])
     home.things.find(params[:weather_id])
   end
 end

--- a/app/controllers/things/thermostats_controller.rb
+++ b/app/controllers/things/thermostats_controller.rb
@@ -2,7 +2,7 @@ class Things::ThermostatsController < ThingsController
   before_action :authenticate_user
 
   def create
-    home = Home.find(params[:home_id])
+    home = current_user.homes.find(params[:home_id])
     thing = home.thermostats.build(thing_params)
 
     if thing.save

--- a/app/controllers/things/weathers_controller.rb
+++ b/app/controllers/things/weathers_controller.rb
@@ -2,7 +2,7 @@ class Things::WeathersController < ThingsController
   before_action :authenticate_user
 
   def create
-    home = Home.find(params[:home_id])
+    home = current_user.homes.find(params[:home_id])
     thing = home.weathers.build(thing_params)
 
     if thing.save

--- a/app/controllers/things_controller.rb
+++ b/app/controllers/things_controller.rb
@@ -2,21 +2,21 @@ class ThingsController < ApplicationController
   before_action :authenticate_user
 
   def index
-    home = Home.find(params[:home_id])
+    home = current_user.homes.find(params[:home_id])
     things = home.things
 
     render json: things
   end
 
   def show
-    home = Home.find(params[:home_id])
+    home = current_user.homes.find(params[:home_id])
     thing = home.things.find(params[:id])
 
     render json: thing
   end
 
   def update
-    home = Home.find(params[:home_id])
+    home = current_user.homes.find(params[:home_id])
     thing = home.things.find(params[:id])
 
     if thing.update(thing_params)
@@ -27,7 +27,7 @@ class ThingsController < ApplicationController
   end
 
   def destroy
-    home = Home.find(params[:home_id])
+    home = current_user.homes.find(params[:home_id])
     thing = home.things.find(params[:id])
 
     thing.destroy

--- a/spec/controllers/discovery_controller_spec.rb
+++ b/spec/controllers/discovery_controller_spec.rb
@@ -13,6 +13,16 @@ describe Things::DiscoveryController, type: :controller do
       expect(parsed_response).to eq(devices)
     end
 
+    it "should return not found response" do
+      user = create(:user)
+      home = create(:home)
+
+      authenticate(user)
+      get :index, params: { home_id: home.id, type: "light" }
+
+      expect(response).to be_not_found
+    end
+
     it "should return bad request response" do
       home = create(:home)
 

--- a/spec/controllers/lights_controller_spec.rb
+++ b/spec/controllers/lights_controller_spec.rb
@@ -13,6 +13,16 @@ describe Things::LightsController, type: :controller do
 
       expect(response.body).to eq(json)
     end
+
+    it "returns a not found status code" do
+      other_home = create(:home)
+      create_list(:light, 3, home: other_home)
+
+      authenticate(home.user)
+      get :index, params: { home_id: other_home.id }
+
+      expect(response).to have_http_status(:not_found)
+    end
   end
 
   describe "GET #show" do
@@ -27,10 +37,11 @@ describe Things::LightsController, type: :controller do
     end
 
     it "returns a not found status code" do
-      light = create(:light)
+      other_home = create(:home)
+      light = create(:light, home: other_home)
 
       authenticate(home.user)
-      get :show, params: { home_id: home.id, id: light.id }
+      get :index, params: { home_id: other_home.id, light_id: light.id }
 
       expect(response).to have_http_status(:not_found)
     end
@@ -56,6 +67,16 @@ describe Things::LightsController, type: :controller do
       expect(parsed_response[:subtype]).to eq(light_params[:subtype])
       expect(parsed_response[:connection_info]).to eq(light_params[:connection_info])
     end
+
+    it "returns a not found status code" do
+      other_home = create(:home)
+      light_params = attributes_for(:light)
+
+      authenticate(home.user)
+      post :create, params: { home_id: other_home.id, light: light_params }
+
+      expect(response).to have_http_status(:not_found)
+    end
   end
 
   describe "PUT #update" do
@@ -72,11 +93,12 @@ describe Things::LightsController, type: :controller do
     end
 
     it "returns a not found status code" do
-      light = create(:light)
+      other_home = create(:home)
+      light = create(:light, home: other_home)
       light_params = attributes_for(:light)
 
       authenticate(home.user)
-      put :update, params: { home_id: home.id, id: light.id, light: light_params }
+      put :update, params: { home_id: other_home.id, id: light.id, light: light_params }
 
       expect(response).to have_http_status(:not_found)
     end
@@ -94,10 +116,11 @@ describe Things::LightsController, type: :controller do
     end
 
     it "returns a not found status code" do
-      light = create(:light)
+      other_home = create(:home)
+      light = create(:light, home: other_home)
 
       authenticate(home.user)
-      delete :destroy, params: { home_id: home.id, id: light.id }
+      delete :destroy, params: { home_id: other_home.id, id: light.id }
 
       expect(response).to have_http_status(:not_found)
     end

--- a/spec/controllers/lights_status_controller_spec.rb
+++ b/spec/controllers/lights_status_controller_spec.rb
@@ -14,6 +14,16 @@ describe Things::Status::LightController, type: :controller do
 
       expect(parsed_response).to eq(light_status)
     end
+
+    it "should return a not found response" do
+      other_home = create(:home)
+      light = create(:light, home: other_home)
+
+      authenticate(home.user)
+      get :show, params: { home_id: other_home.id, light_id: light.id }
+
+      expect(response).to be_not_found
+    end
   end
 
   describe "PUT #update" do
@@ -26,6 +36,16 @@ describe Things::Status::LightController, type: :controller do
       put :update, params: { home_id: home.id, light_id: light.id, status: light_status }
 
       expect(parsed_response).to eq(light_status)
+    end
+
+    it "should return a not found response" do
+      other_home = create(:home)
+      light = create(:light, home: other_home)
+
+      authenticate(home.user)
+      put :update, params: { home_id: other_home.id, light_id: light.id }
+
+      expect(response).to be_not_found
     end
   end
 end

--- a/spec/controllers/locks_controller_spec.rb
+++ b/spec/controllers/locks_controller_spec.rb
@@ -13,6 +13,16 @@ describe Things::LocksController, type: :controller do
 
       expect(response.body).to eq(json)
     end
+
+    it "returns a not found status code" do
+      other_home = create(:home)
+      create_list(:lock, 3, home: other_home)
+
+      authenticate(home.user)
+      get :index, params: { home_id: other_home.id }
+
+      expect(response).to have_http_status(:not_found)
+    end
   end
 
   describe "GET #show" do
@@ -27,10 +37,11 @@ describe Things::LocksController, type: :controller do
     end
 
     it "returns a not found status code" do
-      lock = create(:lock)
+      other_home = create(:home)
+      lock = create(:lock, home: other_home)
 
       authenticate(home.user)
-      get :show, params: { home_id: home.id, id: lock.id }
+      get :index, params: { home_id: other_home.id, lock_id: lock.id }
 
       expect(response).to have_http_status(:not_found)
     end
@@ -56,6 +67,16 @@ describe Things::LocksController, type: :controller do
       expect(parsed_response[:subtype]).to eq(lock_params[:subtype])
       expect(parsed_response[:connection_info]).to eq(lock_params[:connection_info])
     end
+
+    it "returns a not found status code" do
+      other_home = create(:home)
+      lock_params = attributes_for(:lock)
+
+      authenticate(home.user)
+      post :create, params: { home_id: other_home.id, lock: lock_params }
+
+      expect(response).to have_http_status(:not_found)
+    end
   end
 
   describe "PUT #update" do
@@ -72,11 +93,12 @@ describe Things::LocksController, type: :controller do
     end
 
     it "returns a not found status code" do
-      lock = create(:lock)
+      other_home = create(:home)
+      lock = create(:lock, home: other_home)
       lock_params = attributes_for(:lock)
 
       authenticate(home.user)
-      put :update, params: { home_id: home.id, id: lock.id, lock: lock_params }
+      put :update, params: { home_id: other_home.id, id: lock.id, lock: lock_params }
 
       expect(response).to have_http_status(:not_found)
     end
@@ -94,10 +116,11 @@ describe Things::LocksController, type: :controller do
     end
 
     it "returns a not found status code" do
-      lock = create(:lock)
+      other_home = create(:home)
+      lock = create(:lock, home: other_home)
 
       authenticate(home.user)
-      delete :destroy, params: { home_id: home.id, id: lock.id }
+      delete :destroy, params: { home_id: other_home.id, id: lock.id }
 
       expect(response).to have_http_status(:not_found)
     end

--- a/spec/controllers/locks_status_controller_spec.rb
+++ b/spec/controllers/locks_status_controller_spec.rb
@@ -14,6 +14,16 @@ describe Things::Status::LockController, type: :controller do
 
       expect(parsed_response).to eq(lock_status)
     end
+
+    it "should return a not found response" do
+      other_home = create(:home)
+      lock = create(:lock, home: other_home)
+
+      authenticate(home.user)
+      get :show, params: { home_id: other_home.id, lock_id: lock.id }
+
+      expect(response).to be_not_found
+    end
   end
 
   describe "PUT #update" do
@@ -26,6 +36,16 @@ describe Things::Status::LockController, type: :controller do
       put :update, params: { home_id: home.id, lock_id: lock.id, status: lock_status }
 
       expect(parsed_response).to eq(lock_status)
+    end
+
+    it "should return a not found response" do
+      other_home = create(:home)
+      lock = create(:lock, home: other_home)
+
+      authenticate(home.user)
+      put :update, params: { home_id: other_home.id, lock_id: lock.id }
+
+      expect(response).to be_not_found
     end
   end
 end

--- a/spec/controllers/thermostats_controller_spec.rb
+++ b/spec/controllers/thermostats_controller_spec.rb
@@ -13,6 +13,16 @@ describe Things::ThermostatsController, type: :controller do
 
       expect(response.body).to eq(json)
     end
+
+    it "returns a not found status code" do
+      other_home = create(:home)
+      create_list(:thermostat, 3, home: other_home)
+
+      authenticate(home.user)
+      get :index, params: { home_id: other_home.id }
+
+      expect(response).to have_http_status(:not_found)
+    end
   end
 
   describe "GET #show" do
@@ -27,10 +37,11 @@ describe Things::ThermostatsController, type: :controller do
     end
 
     it "returns a not found status code" do
-      thermostat = create(:thermostat)
+      other_home = create(:home)
+      thermostat = create(:thermostat, home: other_home)
 
       authenticate(home.user)
-      get :show, params: { home_id: home.id, id: thermostat.id }
+      get :index, params: { home_id: other_home.id, thermostat_id: thermostat.id }
 
       expect(response).to have_http_status(:not_found)
     end
@@ -56,6 +67,16 @@ describe Things::ThermostatsController, type: :controller do
       expect(parsed_response[:subtype]).to eq(thermostat_params[:subtype])
       expect(parsed_response[:connection_info]).to eq(thermostat_params[:connection_info])
     end
+
+    it "returns a not found status code" do
+      other_home = create(:home)
+      thermostat_params = attributes_for(:thermostat)
+
+      authenticate(home.user)
+      post :create, params: { home_id: other_home.id, thermostat: thermostat_params }
+
+      expect(response).to have_http_status(:not_found)
+    end
   end
 
   describe "PUT #update" do
@@ -72,11 +93,12 @@ describe Things::ThermostatsController, type: :controller do
     end
 
     it "returns a not found status code" do
-      thermostat = create(:thermostat)
+      other_home = create(:home)
+      thermostat = create(:thermostat, home: other_home)
       thermostat_params = attributes_for(:thermostat)
 
       authenticate(home.user)
-      put :update, params: { home_id: home.id, id: thermostat.id, thermostat: thermostat_params }
+      put :update, params: { home_id: other_home.id, id: thermostat.id, thermostat: thermostat_params }
 
       expect(response).to have_http_status(:not_found)
     end
@@ -94,10 +116,11 @@ describe Things::ThermostatsController, type: :controller do
     end
 
     it "returns a not found status code" do
-      thermostat = create(:thermostat)
+      other_home = create(:home)
+      thermostat = create(:thermostat, home: other_home)
 
       authenticate(home.user)
-      delete :destroy, params: { home_id: home.id, id: thermostat.id }
+      delete :destroy, params: { home_id: other_home.id, id: thermostat.id }
 
       expect(response).to have_http_status(:not_found)
     end

--- a/spec/controllers/thermostats_status_controller_spec.rb
+++ b/spec/controllers/thermostats_status_controller_spec.rb
@@ -14,6 +14,16 @@ describe Things::Status::ThermostatController, type: :controller do
 
       expect(parsed_response).to eq(thermostat_status)
     end
+
+    it "should return a not found response" do
+      other_home = create(:home)
+      thermostat = create(:thermostat, home: other_home)
+
+      authenticate(home.user)
+      get :show, params: { home_id: other_home.id, thermostat_id: thermostat.id }
+
+      expect(response).to be_not_found
+    end
   end
 
   describe "PUT #update" do
@@ -26,6 +36,16 @@ describe Things::Status::ThermostatController, type: :controller do
       put :update, params: { home_id: home.id, thermostat_id: thermostat.id, status: thermostat_status }
 
       expect(parsed_response).to eq(thermostat_status)
+    end
+
+    it "should return a not found response" do
+      other_home = create(:home)
+      thermostat = create(:thermostat, home: other_home)
+
+      authenticate(home.user)
+      put :update, params: { home_id: other_home.id, thermostat_id: thermostat.id }
+
+      expect(response).to be_not_found
     end
   end
 end

--- a/spec/controllers/weathers_controller_spec.rb
+++ b/spec/controllers/weathers_controller_spec.rb
@@ -13,6 +13,16 @@ describe Things::WeathersController, type: :controller do
 
       expect(response.body).to eq(json)
     end
+
+    it "returns a not found status code" do
+      other_home = create(:home)
+      create_list(:weather, 3, home: other_home)
+
+      authenticate(home.user)
+      get :index, params: { home_id: other_home.id }
+
+      expect(response).to have_http_status(:not_found)
+    end
   end
 
   describe "GET #show" do
@@ -27,10 +37,11 @@ describe Things::WeathersController, type: :controller do
     end
 
     it "returns a not found status code" do
-      weather = create(:weather)
+      other_home = create(:home)
+      weather = create(:weather, home: other_home)
 
       authenticate(home.user)
-      get :show, params: { home_id: home.id, id: weather.id }
+      get :index, params: { home_id: other_home.id, weather_id: weather.id }
 
       expect(response).to have_http_status(:not_found)
     end
@@ -56,6 +67,16 @@ describe Things::WeathersController, type: :controller do
       expect(parsed_response[:subtype]).to eq(weather_params[:subtype])
       expect(parsed_response[:connection_info]).to eq(weather_params[:connection_info])
     end
+
+    it "returns a not found status code" do
+      other_home = create(:home)
+      weather_params = attributes_for(:weather)
+
+      authenticate(home.user)
+      post :create, params: { home_id: other_home.id, weather: weather_params }
+
+      expect(response).to have_http_status(:not_found)
+    end
   end
 
   describe "PUT #update" do
@@ -72,11 +93,12 @@ describe Things::WeathersController, type: :controller do
     end
 
     it "returns a not found status code" do
-      weather = create(:weather)
+      other_home = create(:home)
+      weather = create(:weather, home: other_home)
       weather_params = attributes_for(:weather)
 
       authenticate(home.user)
-      put :update, params: { home_id: home.id, id: weather.id, weather: weather_params }
+      put :update, params: { home_id: other_home.id, id: weather.id, weather: weather_params }
 
       expect(response).to have_http_status(:not_found)
     end
@@ -94,10 +116,11 @@ describe Things::WeathersController, type: :controller do
     end
 
     it "returns a not found status code" do
-      weather = create(:weather)
+      other_home = create(:home)
+      weather = create(:weather, home: other_home)
 
       authenticate(home.user)
-      delete :destroy, params: { home_id: home.id, id: weather.id }
+      delete :destroy, params: { home_id: other_home.id, id: weather.id }
 
       expect(response).to have_http_status(:not_found)
     end

--- a/spec/controllers/weathers_status_controller_spec.rb
+++ b/spec/controllers/weathers_status_controller_spec.rb
@@ -14,5 +14,15 @@ describe Things::Status::WeatherController, type: :controller do
 
       expect(parsed_response).to eq(weather_status)
     end
+
+    it "should return a not found response" do
+      other_home = create(:home)
+      weather = create(:weather, home: other_home)
+
+      authenticate(home.user)
+      get :show, params: { home_id: other_home.id, weather_id: weather.id }
+
+      expect(response).to be_not_found
+    end
   end
 end


### PR DESCRIPTION
Rework all routes so that when a user tries to access a home or the things on a home that does not belong to him, it should return a 404 code.

If user X has house Y, and user Z tries to access house Y, we basically say to them "hey, there is no such house".